### PR TITLE
fix: avoid logging the same resolved layer multiple times

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ class ServerlessPlugin {
     this.serverless = serverless;
     this.provider = serverless.getProvider("aws");
     this.options = options;
+    this.resolvedLayers = [];
 
     this.hooks = {
       'after:aws:package:finalize:mergeCustomProviderResources': this.updateCFNLayerVersion.bind(this),
@@ -181,6 +182,9 @@ class ServerlessPlugin {
           const resolvedLayerArn = arnVersionMap.get(node);
           if (resolvedLayerArn) {
             this.update(resolvedLayerArn);
+            // Avoid logging the same resolved layer multiple times
+            if (self.resolvedLayers.some(item => item === resolvedLayerArn)) return
+            self.resolvedLayers.push(resolvedLayerArn);
             self.log("Resolved %s to %s", node, resolvedLayerArn);
           } else {
             self.log("Detected unknown Layer ARN %s. Please create a new issue to github.com/mooyoul/serverless-latest-layer-version", node);

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ class ServerlessPlugin {
     this.serverless = serverless;
     this.provider = serverless.getProvider("aws");
     this.options = options;
-    this.resolvedLayers = [];
+    this.resolvedLayers = new Set();
 
     this.hooks = {
       'after:aws:package:finalize:mergeCustomProviderResources': this.updateCFNLayerVersion.bind(this),
@@ -183,8 +183,10 @@ class ServerlessPlugin {
           if (resolvedLayerArn) {
             this.update(resolvedLayerArn);
             // Avoid logging the same resolved layer multiple times
-            if (self.resolvedLayers.some(item => item === resolvedLayerArn)) return
-            self.resolvedLayers.push(resolvedLayerArn);
+            if (self.resolvedLayers.has(resolvedLayerArn)) {
+              return;
+            }
+            self.resolvedLayers.add(resolvedLayerArn);
             self.log("Resolved %s to %s", node, resolvedLayerArn);
           } else {
             self.log("Detected unknown Layer ARN %s. Please create a new issue to github.com/mooyoul/serverless-latest-layer-version", node);


### PR DESCRIPTION
In my use case, I have about 30 lambdas and each one of them have the same 2 layers, which makes the terminal look like this on every deploy:

<img width="1169" alt="image" src="https://user-images.githubusercontent.com/19496473/183102227-44657e7a-1f4e-42bd-aacd-265150539446.png">

This small fix caches the resolved layers and only log once for each one, making it look a little more pleasent.

<img width="1164" alt="image" src="https://user-images.githubusercontent.com/19496473/183102939-69ffd7df-85a5-416d-99cc-e1b575e96379.png">
